### PR TITLE
Fix FoodFinder request handling after package upgrade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Make sure to add http or axios will throw an error
+GOOGLE_AI_STUDIO_API_KEY=
 NEXT_PUBLIC_API_URL=http://localhost:3000/api

--- a/src/components/forms/FoodFinder/index.tsx
+++ b/src/components/forms/FoodFinder/index.tsx
@@ -103,16 +103,28 @@ const FoodFinder = ({ theme }: { theme: string }) => {
         setRecommendations([]);
         loadingAnimationHandlers.open();
         openModalHandlers.open();
-        await fetch("/api/food-finder", {
-            method: "POST",
-            body: JSON.stringify(values),
-        })
-            .then((res) => res.json())
-            .then((data) => setRecommendations(data.recommendation))
-            .then(() => {
-                loadingAnimationHandlers.close();
-                openModalHandlers.open();
+        try {
+            const response = await fetch("/api/food-finder", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(values),
             });
+            const data = await response.json();
+
+            if (!response.ok) {
+                throw new Error(data.message ?? "Unable to generate recommendations.");
+            }
+
+            setRecommendations(data.recommendation ?? []);
+        } catch (error) {
+            console.error("food-finder request failed", error);
+            setRecommendations([]);
+        } finally {
+            loadingAnimationHandlers.close();
+            openModalHandlers.open();
+        }
     }
 };
 

--- a/src/pages/api/food-finder.ts
+++ b/src/pages/api/food-finder.ts
@@ -1,7 +1,7 @@
 import {FormProps} from "@/utils/types/forms";
 import {NextApiRequest, NextApiResponse} from "next";
 import {DEFAULT_RESPONSES} from "@/utils/errors/default";
-import {formatPrompt, promptModel} from "@/utils/helpers/prompt";
+import {formatPrompt, promptModel, PromptModelError} from "@/utils/helpers/prompt";
 
 interface FormRequest extends NextApiRequest {
     body: FormProps | string;
@@ -34,9 +34,12 @@ const handler = async (
         return res.status(DEFAULT_RESPONSES.CREATED.status).json({recommendation: recommendationList});
     } catch (error) {
         console.error("food-finder handler failed", error);
+        const message = error instanceof PromptModelError
+            ? error.message
+            : DEFAULT_RESPONSES.INTERNAL_SERVER_ERROR.message;
         return res
             .status(DEFAULT_RESPONSES.INTERNAL_SERVER_ERROR.status)
-            .json({message: DEFAULT_RESPONSES.INTERNAL_SERVER_ERROR.message});
+            .json({message});
     }
 };
 

--- a/src/pages/api/food-finder.ts
+++ b/src/pages/api/food-finder.ts
@@ -4,7 +4,7 @@ import {DEFAULT_RESPONSES} from "@/utils/errors/default";
 import {formatPrompt, promptModel} from "@/utils/helpers/prompt";
 
 interface FormRequest extends NextApiRequest {
-    body: FormProps;
+    body: FormProps | string;
 }
 
 const handler = async (
@@ -12,21 +12,32 @@ const handler = async (
     res: NextApiResponse<{ message: string } | { recommendation: string[] }>
 ) => {
     if (req.method !== "POST") {
-        res.status(DEFAULT_RESPONSES.FORBIDDEN.status).json({message: DEFAULT_RESPONSES.FORBIDDEN.message});
+        return res.status(DEFAULT_RESPONSES.FORBIDDEN.status).json({message: DEFAULT_RESPONSES.FORBIDDEN.message});
     }
 
-    const data: FormProps = JSON.parse(req.body as unknown as string);
-    if (!data) {
-        res.status(DEFAULT_RESPONSES.BAD_REQUEST.status).json({message: DEFAULT_RESPONSES.BAD_REQUEST.message});
+    try {
+        const data: FormProps = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+
+        if (!data) {
+            return res.status(DEFAULT_RESPONSES.BAD_REQUEST.status).json({message: DEFAULT_RESPONSES.BAD_REQUEST.message});
+        }
+
+        const promptMessage: string = formatPrompt(data);
+        const recommendation: string = await promptModel(promptMessage);
+
+        // parse recommendation as array of strings and preprocess
+        const recommendationList: string[] = recommendation
+            .replace(/["'\[\]\n\t]/g, "")
+            .split(", ")
+            .filter(Boolean);
+
+        return res.status(DEFAULT_RESPONSES.CREATED.status).json({recommendation: recommendationList});
+    } catch (error) {
+        console.error("food-finder handler failed", error);
+        return res
+            .status(DEFAULT_RESPONSES.INTERNAL_SERVER_ERROR.status)
+            .json({message: DEFAULT_RESPONSES.INTERNAL_SERVER_ERROR.message});
     }
-
-    const promptMessage: string = formatPrompt(data);
-    const recommendation: string = await promptModel(promptMessage);
-
-    // parse recommendation as array of strings and preprocess
-    const recommendationList: string[] = recommendation.replace(/["'\[\]\n\t]/g, "").split(", ");
-
-    res.status(DEFAULT_RESPONSES.CREATED.status).json({recommendation: recommendationList});
 };
 
 export default handler;

--- a/src/utils/helpers/prompt.ts
+++ b/src/utils/helpers/prompt.ts
@@ -3,14 +3,36 @@ import 'dotenv/config'
 import {FormProps} from "@/utils/types/forms";
 
 const GOOGLE_AI_STUDIO_API_KEY: string | undefined = process.env.GOOGLE_AI_STUDIO_API_KEY;
-const genAI = new GoogleGenerativeAI(<string>GOOGLE_AI_STUDIO_API_KEY);
+const MODEL_NAME = "gemini-1.5-flash";
+
+export class PromptModelError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "PromptModelError";
+    }
+}
 
 export const promptModel = async (prompt: string): Promise<string> => {
-    // The Gemini 1.5 models are versatile and work with both text-only and multimodal prompts
-    const model = genAI.getGenerativeModel({model: "gemini-1.5-flash"});
+    if (!GOOGLE_AI_STUDIO_API_KEY) {
+        throw new PromptModelError("Missing GOOGLE_AI_STUDIO_API_KEY server environment variable.");
+    }
 
-    const result = await model.generateContent(prompt);
-    return result.response.text();
+    try {
+        // The Gemini 1.5 models are versatile and work with both text-only and multimodal prompts
+        const genAI = new GoogleGenerativeAI(GOOGLE_AI_STUDIO_API_KEY);
+        const model = genAI.getGenerativeModel({model: MODEL_NAME});
+        const result = await model.generateContent(prompt);
+        const responseText = result.response.text().trim();
+
+        if (!responseText) {
+            throw new PromptModelError(`Model ${MODEL_NAME} returned an empty response.`);
+        }
+
+        return responseText;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new PromptModelError(message);
+    }
 }
 
 export const formatPrompt = (data: FormProps): string => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix the FoodFinder API route to accept either a parsed JSON body or a raw JSON string
- return proper API errors instead of throwing through the request lifecycle
- ensure the FoodFinder modal always clears its loading state when generation fails
- surface Gemini configuration failures clearly when the server API key is missing or invalid

## Root cause
After the dependency upgrade, the app moved to Next.js 15. In the `pages/api/food-finder` route, the code still did `JSON.parse(req.body as string)`. With the upgraded Next.js request handling, `req.body` is already parsed for JSON requests, so parsing it again can throw `SyntaxError: "[object Object]" is not valid JSON`.

That server failure bubbled back to the browser, but the client code never handled a failed `fetch()` response or exception. As a result, the loading overlay stayed open indefinitely, which made the LLM generation appear to be stuck in an infinite loop even though the request had already failed.

## Current API key diagnosis
I also verified the Gemini call path directly in the current runtime:
- `GOOGLE_AI_STUDIO_API_KEY` is not present in the server environment in this workspace
- a direct `@google/generative-ai` test call fails with `API_KEY_INVALID`
- the configured model name `gemini-1.5-flash` is not the immediate blocker here; the key availability/validity is

## Validation
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ccdcb9c-de09-4a44-a875-ea17aa3580a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ccdcb9c-de09-4a44-a875-ea17aa3580a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

