### PR TITLE
Fix Geoapify restaurant lookup flow

### DIFF
--- a/src/components/forms/Election/index.tsx
+++ b/src/components/forms/Election/index.tsx
@@ -5,6 +5,7 @@ import Session from "@/firebase/interfaces/session";
 import SessionRepository from "@/firebase/repository/sessionRepository";
 import useLocationStore from "@/stores/useLocationStore";
 import { Anchor, Group, NumberInput, Table, Text } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
 import axios, { AxiosResponse } from "axios";
 import { DocumentData, DocumentReference, onSnapshot } from "firebase/firestore";
 import { nanoid } from "nanoid";
@@ -23,39 +24,52 @@ const Election = ({ theme }: { theme: string }) => {
 
     const fetchRestaurants = useCallback(async () => {
         if (isLoading) return;
+
+        const hasResolvedLocation = place_id.trim().length > 0 && Number(lat) !== 0 && Number(lon) !== 0;
+
+        if (!hasResolvedLocation) {
+            notifications.show({
+                color: "red",
+                message: "Pick a location from the Geoapify suggestions or use your current location before starting voting.",
+            });
+            return;
+        }
+
         setIsLoading(true);
 
-        const res: AxiosResponse<RestaurantFinder.Feature[]> = await axios<RestaurantFinder.Feature[]>(
-            "/api/restaurant-finder",
-            {
-                params: { lat, lon, radius: searchRadius },
-            },
-        );
+        try {
+            const res: AxiosResponse<RestaurantFinder.Feature[]> = await axios<RestaurantFinder.Feature[]>(
+                "/api/restaurant-finder",
+                {
+                    params: { lat, lon, radius: searchRadius },
+                },
+            );
 
-        if (res.status !== 200) return;
+            if (res.status !== 200) return;
 
-        // take only 1st 15 restaurants
-        const restaurantData: RestaurantFinder.Feature[] = res.data.slice(0, 15);
+            // take only 1st 15 restaurants
+            const restaurantData: RestaurantFinder.Feature[] = res.data.slice(0, 15);
 
-        const sid: string = nanoid();
-        setSessionId(sid);
+            const sid: string = nanoid();
+            setSessionId(sid);
 
-        setSessionRef(
-            await SessionRepository.add({
-                location_id: place_id,
-                session_id: sid,
-                listing: restaurantData.map((d) => ({
-                    cuisine: d.properties.catering?.cuisine ?? "",
-                    id: d.properties.place_id,
-                    location: d.properties.formatted ?? "Unknown Location",
-                    name: d.properties.name_international?.en ?? d.properties.name ?? "Unknown Restaurant",
-                    votes: [],
-                    image: "https://raw.githubusercontent.com/mantinedev/mantine/master/.demo/images/bg-8.png",
-                })),
-            }),
-        );
-
-        setIsLoading(false);
+            setSessionRef(
+                await SessionRepository.add({
+                    location_id: place_id,
+                    session_id: sid,
+                    listing: restaurantData.map((d) => ({
+                        cuisine: d.properties.catering?.cuisine ?? "",
+                        id: d.properties.place_id,
+                        location: d.properties.formatted ?? "Unknown Location",
+                        name: d.properties.name_international?.en ?? d.properties.name ?? "Unknown Restaurant",
+                        votes: [],
+                        image: "https://raw.githubusercontent.com/mantinedev/mantine/master/.demo/images/bg-8.png",
+                    })),
+                }),
+            );
+        } finally {
+            setIsLoading(false);
+        }
     }, [isLoading, searchRadius, lat, lon, place_id]);
 
     useEffect(() => {

--- a/src/components/input/LocationInput.tsx
+++ b/src/components/input/LocationInput.tsx
@@ -1,14 +1,13 @@
 import useLocationStore from "@/stores/useLocationStore";
 import { Autocomplete, Box, LoadingOverlay, rem } from "@mantine/core";
-import { useDebouncedValue, useDisclosure } from "@mantine/hooks";
+import { useDebouncedValue } from "@mantine/hooks";
 import { IconMapPin } from "@tabler/icons-react";
 import axios from "axios";
 import "dotenv/config";
 import { useCallback, useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
-const LocationInput = ({ theme }: { theme: string }) => {
-    const [loadingAnimation, loadingAnimationHandlers] = useDisclosure(false);
+const LocationInput = ({ theme: _theme }: { theme: string }) => {
     const [locationName, setLocationName, setLatitude, setLongitude, setLocationId] = useLocationStore(
         useShallow((state) => [
             state.locationName,
@@ -35,6 +34,26 @@ const LocationInput = ({ theme }: { theme: string }) => {
     useEffect(() => {
         fetchAddressAutocomplete();
     }, [fetchAddressAutocomplete]);
+
+    const syncSelectedAddress = useCallback(
+        (value: string) => {
+            const selectedAddress = addressOptions.find((option) => option.formatted === value);
+
+            setLocationName(value);
+
+            if (selectedAddress == null) {
+                setLocationId("");
+                setLatitude("0");
+                setLongitude("0");
+                return;
+            }
+
+            setLocationId(selectedAddress.place_id);
+            setLatitude(selectedAddress.lat.toString());
+            setLongitude(selectedAddress.lon.toString());
+        },
+        [addressOptions, setLatitude, setLongitude, setLocationId, setLocationName],
+    );
 
     const getUserLocation = useCallback(() => {
         if (isLoading === true) return;
@@ -75,22 +94,12 @@ const LocationInput = ({ theme }: { theme: string }) => {
         <>
             <Box mt={"xl"}>
                 <Box pos="relative">
-                    <LoadingOverlay visible={loadingAnimation} zIndex={1000} opacity={0.5} />
+                    <LoadingOverlay visible={isLoading} zIndex={1000} overlayProps={{ opacity: 0.5 }} />
                     <Autocomplete
-                        data={addressOptions.map((a) => ({
-                            value: a.formatted,
-                            lat: a.lat,
-                            lon: a.lon,
-                            place_id: a.place_id,
-                        }))}
+                        data={addressOptions.map((a) => a.formatted)}
                         value={locationName}
-                        onChange={setLocationName}
-                        onOptionSubmit={(item: any) => {
-                            setLocationName(item.value);
-                            setLocationId(item.place_id);
-                            setLatitude(item.lat);
-                            setLongitude(item.lon);
-                        }}
+                        onChange={syncSelectedAddress}
+                        onOptionSubmit={syncSelectedAddress}
                         label="Enter your location"
                         placeholder="Cheras, Kuala Lumpur"
                         rightSectionProps={{ style: { cursor: "pointer" } }}

--- a/src/pages/api/restaurant-finder.ts
+++ b/src/pages/api/restaurant-finder.ts
@@ -19,7 +19,7 @@ interface RestaurantFinderRequest extends NextApiRequest {
 
 const GEOAPIFY_API_KEY: string | undefined = process.env.GEOAPIFY_KEY;
 
-const handler = async (req: RestaurantFinderRequest, res: NextApiResponse) => {
+const handler = async (req: RestaurantFinderRequest, res: NextApiResponse<RestaurantFinder.Feature[] | { message: string }>) => {
     const { success, data } = RestaurantFinderQuerySchema.safeParse(req.query);
 
     if (!success) {
@@ -27,30 +27,51 @@ const handler = async (req: RestaurantFinderRequest, res: NextApiResponse) => {
         return;
     }
 
-    const result = await axios<RestaurantFinder.Response>("https://api.geoapify.com/v2/places", {
-        method: "GET",
-        params: {
-            categories: "catering.restaurant",
-            filter: `circle:${data.lon},${data.lat},${data.radius * 1000}`,
-            limit: 100,
-            bias: `proximity:${data.lon},${data.lat}`,
-            apiKey: GEOAPIFY_API_KEY,
-        },
-    });
-
-    if (result.status !== 200) {
-        res.status(DEFAULT_RESPONSES.BAD_REQUEST.status).json({ message: DEFAULT_RESPONSES.BAD_REQUEST.message });
+    if (GEOAPIFY_API_KEY == null || GEOAPIFY_API_KEY.trim().length === 0) {
+        res.status(DEFAULT_RESPONSES.INTERNAL_SERVER_ERROR.status).json({
+            message: "Geoapify API key is missing. Set GEOAPIFY_KEY before requesting restaurants.",
+        });
         return;
     }
 
-    const filtered = result.data.features.filter((f) => f.properties.name != null);
+    try {
+        const result = await axios<RestaurantFinder.Response>("https://api.geoapify.com/v2/places", {
+            method: "GET",
+            params: {
+                categories: "catering.restaurant",
+                filter: `circle:${data.lon},${data.lat},${data.radius * 1000}`,
+                limit: 100,
+                bias: `proximity:${data.lon},${data.lat}`,
+                apiKey: GEOAPIFY_API_KEY,
+            },
+        });
 
-    if (filtered.length === 0) {
-        res.json([]);
+        const filtered = result.data.features.filter((f) => f.properties.name != null);
+
+        if (filtered.length === 0) {
+            res.json([]);
+            return;
+        }
+
+        res.json(shuffle(filtered));
+        return;
+    } catch (error) {
+        if (axios.isAxiosError(error)) {
+            const status = error.response?.status ?? DEFAULT_RESPONSES.BAD_REQUEST.status;
+            const geoapifyMessage =
+                typeof error.response?.data?.message === "string"
+                    ? error.response.data.message
+                    : error.message;
+
+            res.status(status).json({ message: `Geoapify Places API error: ${geoapifyMessage}` });
+            return;
+        }
+
+        res.status(DEFAULT_RESPONSES.INTERNAL_SERVER_ERROR.status).json({
+            message: DEFAULT_RESPONSES.INTERNAL_SERVER_ERROR.message,
+        });
         return;
     }
-
-    return res.json(shuffle(filtered));
 };
 
 export default handler;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix the location autocomplete flow so selecting a suggestion stores the resolved Geoapify coordinates instead of leaving the app at the default `0,0` coordinates
- block election creation until a location has actually been resolved and show a clear UI message when it has not
- surface Geoapify Places API failures directly from `/api/restaurant-finder`, including a specific error when `GEOAPIFY_KEY` is missing

## Root cause
The restaurant loader was not primarily failing because the Places API request shape was wrong. The bigger bug was in `LocationInput`: Mantine `Autocomplete` is string-based, but the code treated `onOptionSubmit` as if it returned an object containing `lat`, `lon`, and `place_id`. That meant the UI could display a valid location label while the store still held `latitude="0"` and `longitude="0"`, so the restaurant search queried Geoapify around `0,0` instead of the selected city.

The API route also swallowed Geoapify failures and returned a generic bad request, which hid the actual backend problem.

## API error identified
In this cloud environment, `GEOAPIFY_KEY` is not configured, so Geoapify requests would fail here even after the client bug was fixed. The route now reports that directly with:
- `Geoapify API key is missing. Set GEOAPIFY_KEY before requesting restaurants.`

If Geoapify returns an HTTP error response (for example invalid credentials or account restrictions), the route now forwards the API message as:
- `Geoapify Places API error: ...`

## Validation
- `npm run lint`
- `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61f339a5-13d0-4f45-9bdd-e896fdd7a97d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61f339a5-13d0-4f45-9bdd-e896fdd7a97d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

